### PR TITLE
Resolved Issue#2 in anurag444/opentracksFall2024

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackEditActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackEditActivity.java
@@ -44,7 +44,6 @@ public class TrackEditActivity extends AbstractActivity implements ChooseActivit
     private static final String ICON_VALUE_KEY = "icon_value_key";
 
     private ContentProviderUtils contentProviderUtils;
-    private Track track;
     private ActivityType activityType;
 
     private TrackEditBinding viewBinding;
@@ -54,6 +53,7 @@ public class TrackEditActivity extends AbstractActivity implements ChooseActivit
         super.onCreate(bundle);
 
         Track.Id trackId = getIntent().getParcelableExtra(EXTRA_TRACK_ID);
+
         if (trackId == null) {
             Log.e(TAG, "invalid trackId");
             finish();
@@ -61,7 +61,7 @@ public class TrackEditActivity extends AbstractActivity implements ChooseActivit
         }
 
         contentProviderUtils = new ContentProviderUtils(this);
-        track = contentProviderUtils.getTrack(trackId);
+        Track track = contentProviderUtils.getTrack(trackId);
         if (track == null) {
             Log.e(TAG, "No track for " + trackId.id());
             finish();


### PR DESCRIPTION
**Describe the pull request**
Resolved the issue #2 which includes Remove the "track" field and declare it as a local variable in the relevant methods because when the value of a private field is always assigned to in a class' methods before being read, then it is not being used to store class information. Therefore, it should become a local variable in the relevant methods to prevent any misunderstanding.

**Resolution Screenshot**
![Screenshot 2024-10-02 192644](https://github.com/user-attachments/assets/0f50a0d0-ceac-4261-b936-48bacb5bc413)


**Link to the the issue**
[Issue#2 Link](https://github.com/anurag444/opentracksFall2024/issues/2)