### PR TITLE
fix: deprecated handler usage

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/AbstractTrackDeleteActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/AbstractTrackDeleteActivity.java
@@ -17,6 +17,8 @@
 package de.dennisguse.opentracks;
 
 import android.os.Handler;
+import android.os.Looper;
+
 import android.widget.Toast;
 
 import java.util.ArrayList;
@@ -54,7 +56,7 @@ public abstract class AbstractTrackDeleteActivity extends AbstractActivity imple
             Toast.makeText(this, getString(R.string.track_delete_not_recording), Toast.LENGTH_LONG).show();
         }
 
-        TrackDeleteService.enqueue(this, new TrackDeleteService.TrackDeleteResultReceiver(new Handler(), this), trackIdList);
+        TrackDeleteService.enqueue(this, new TrackDeleteService.TrackDeleteResultReceiver(new Handler(Looper.getMainLooper()), this), trackIdList);
     }
 
     protected abstract void onDeleteConfirmed();


### PR DESCRIPTION
**Describe the pull request**
This PR fixes issue #X by replacing the deprecated use of `Handler` with `Handler(Looper.getMainLooper())` in `AbstractTrackDeleteActivity.java`.

**Link to the the issue**
https://github.com/anurag444/opentracksFall2024/issues/12

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
